### PR TITLE
Fix such that undefined argv.cwd does not get converted to the string "undefined"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ const makeid = (length: number): string => {
 };
 
 const argv = yargs.argv;
-const cwd = String(argv.cwd) || process.cwd();
+const cwd = String(argv.cwd || process.cwd());
 const m: any = argv.m;
 const manualArgs: string[] = [].concat(m || []);
 


### PR DESCRIPTION
Before if `argv.cwd` was `undefined` it would be converted to the string `"undefined"` resulting in the default `process.cwd()` never being used and we would get an error when running the program that `undefined/.gitlab-ci.yml could not be found`